### PR TITLE
change Remove by RemoveName to fix DeleteRecords not working

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -102,7 +102,7 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 		if err != nil {
 			return nil, fmt.Errorf("invalid record %s: %w", rec.Name, err)
 		}
-		msg.Remove([]dns.RR{rr})
+		msg.RemoveName([]dns.RR{rr})
 	}
 	p.setTsig(&msg)
 


### PR DESCRIPTION
after the issue: https://github.com/libdns/rfc2136/issues/1

i've tested replacing Remove by RemoveName and is working fine (i use bind as dns server).

this example work fine (we need to specify Type record with Name, without that we crash on RemoveName because rr is nil).

```
// delete records 
deletedRecs, err := provider.DeleteRecords(ctx, zone, []libdns.Record{
{
	Name: "sub",
	Type: "A",
},
})
```