### PR TITLE
set correct libdns.Record.Value for records of type dns.RFC3597

### DIFF
--- a/conversion_test.go
+++ b/conversion_test.go
@@ -69,6 +69,21 @@ var testCases = map[dns.RR]libdns.Record{
 		Value: "1:2:3:4::",
 		TTL:   150 * time.Second,
 	},
+
+	&dns.RFC3597{
+		Hdr: dns.RR_Header{
+			Name:   "privateuse.example.com.",
+			Rrtype: 65534,
+			Class:  dns.ClassINET,
+			Ttl:    150,
+		},
+		Rdata: "0d10480001",
+	}: {
+		Type:  "TYPE65534",
+		Name:  "privateuse",
+		Value: `\# 5 0d10480001`,
+		TTL:   150 * time.Second,
+	},
 }
 
 func TestRecordFromRR(t *testing.T) {


### PR DESCRIPTION
Package dns parses private-use records into dns.RFC3597.

Unlike other types of records, the string representation of those records
doesn't start with the string representation of just the header. So account
for that when stripping the header prefix to get the record value.

BIND uses private-use records for DNSSEC state machines.

For issue #6.
