### PR TITLE
restore setting dns record values in the libdns.Record.Value fields

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -11,61 +11,20 @@ import (
 )
 
 func recordToRR(rec libdns.Record, zone string) (dns.RR, error) {
-	rrType := dns.StringToType[rec.Type]
-	rrConstructor := dns.TypeToRR[rrType]
-	var rr dns.RR
-	if rrConstructor == nil {
-		rr = new(dns.RFC3597)
-	} else {
-		rr = rrConstructor()
-	}
-
-	// Create a zone file line representing the record. We're using reflection
-	// so that we can automatically support any new RR types that define these
-	// fields.
 	name := rec.Name
 	if name == "" {
 		name = "@"
 	}
 
-	zoneLine := fmt.Sprintf("%s %d IN %s ", name, int(rec.TTL.Seconds()), rec.Type)
-
-	priority := reflect.ValueOf(rr).Elem().FieldByName("Priority")
-	if !priority.IsValid() {
-		priority = reflect.ValueOf(rr).Elem().FieldByName("Preference")
-	}
-
-	if priority.IsValid() {
-		zoneLine += fmt.Sprintf("%d ", rec.Priority)
-	}
-
-	weight := reflect.ValueOf(rr).Elem().FieldByName("Weight")
-	if weight.IsValid() {
-		zoneLine += fmt.Sprintf("%d ", rec.Weight)
-	}
-
-	target := reflect.ValueOf(rr).Elem().FieldByName("Target")
-	if target.IsValid() {
-		zoneLine += fmt.Sprintf("%s ", rec.Target)
-	}
-
-	if rec.Value != "" {
-		zoneLine += rec.Value
-	}
-	zoneLine = strings.TrimSuffix(zoneLine, " ") + "\n"
-
-	zp := dns.NewZoneParser(strings.NewReader(zoneLine), zone, "")
-	rr, _ = zp.Next()
+	str := fmt.Sprintf("%s %d IN %s %s", name,
+		int(rec.TTL.Seconds()), rec.Type, rec.Value)
+	zp := dns.NewZoneParser(strings.NewReader(str), zone, "")
+	rr, _ := zp.Next()
 	return rr, zp.Err()
 }
 
 func recordFromRR(rr dns.RR, zone string) libdns.Record {
 	hdr := rr.Header()
-
-	rec := libdns.Record{
-		Name: libdns.RelativeName(hdr.Name, zone),
-		TTL:  time.Duration(hdr.Ttl) * time.Second,
-	}
 
 	// The record value is the full record string representation with the header string
 	// prefix stripped. Package dns represents private-use and unknown records as
@@ -80,7 +39,12 @@ func recordFromRR(rr dns.RR, zone string) libdns.Record {
 		hdrStr = fmt.Sprintf("%s\t%d\tCLASS%d\t%s\t", name, hdr.Ttl, hdr.Class, typ)
 	}
 
-	rec.Type = typ
+	rec := libdns.Record{
+		Type:  typ,
+		Name:  libdns.RelativeName(hdr.Name, zone),
+		TTL:   time.Duration(hdr.Ttl) * time.Second,
+		Value: strings.TrimPrefix(rr.String(), hdrStr),
+	}
 
 	// Parse priority, weight, and target from the record value. We're using
 	// reflection so that we can automatically support any new RR types that
@@ -89,28 +53,21 @@ func recordFromRR(rr dns.RR, zone string) libdns.Record {
 	if !priority.IsValid() {
 		priority = reflect.ValueOf(rr).Elem().FieldByName("Preference")
 	}
-
 	if priority.IsValid() {
 		priority := priority.Uint()
 		rec.Priority = uint(priority)
-		hdrStr += fmt.Sprintf("%d ", priority)
 	}
 
 	weight := reflect.ValueOf(rr).Elem().FieldByName("Weight")
 	if weight.IsValid() {
 		weight := weight.Uint()
 		rec.Weight = uint(weight)
-		hdrStr += fmt.Sprintf("%d ", weight)
 	}
 
 	target := reflect.ValueOf(rr).Elem().FieldByName("Target")
 	if target.IsValid() && typ != "SRV" {
 		rec.Target = target.String()
-		hdrStr += fmt.Sprintf("%s ", rec.Target)
 	}
-
-	// Get the value from the record string representation.
-	rec.Value = strings.TrimPrefix(rr.String(), hdrStr)
 
 	return rec
 }

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -123,7 +123,7 @@ var testCases = map[dns.RR]libdns.Record{
 		TTL:      150 * time.Second,
 		Priority: 2,
 		Target:   "target.example.com.",
-		Value:    fmt.Sprintf(`alpn="h3,h2" ipv4hint="127.0.0.1" ipv6hint="::1" ech="%s"`, echString),
+		Value:    fmt.Sprintf(`2 target.example.com. alpn="h3,h2" ipv4hint="127.0.0.1" ipv6hint="::1" ech="%s"`, echString),
 	},
 
 	&dns.MX{
@@ -138,7 +138,7 @@ var testCases = map[dns.RR]libdns.Record{
 	}: {
 		Type:     "MX",
 		Name:     "mx",
-		Value:    "mail.example.com.",
+		Value:    "10 mail.example.com.",
 		TTL:      150 * time.Second,
 		Priority: 10,
 	},
@@ -157,7 +157,7 @@ var testCases = map[dns.RR]libdns.Record{
 	}: {
 		Type:     "SRV",
 		Name:     "srv",
-		Value:    "443 service.example.com.",
+		Value:    "10 20 443 service.example.com.",
 		TTL:      150 * time.Second,
 		Priority: 10,
 		Weight:   20,
@@ -198,7 +198,7 @@ func TestRecordToRR(t *testing.T) {
 	for expected, record := range testCases {
 		converted, err := recordToRR(record, zone)
 		if err != nil {
-			t.Error(err)
+			t.Errorf("recordToRR %v: %v", record, err)
 		}
 		if !rrEqual(expected, converted) {
 			t.Errorf("converted rr does not match expected\nRecord: %#v\nExpected: %#v\nGot: %#v",


### PR DESCRIPTION
This keeps setting Priority/Preference/Weight on libdns.Record based on the dns.RR. But when going from libdns.Record to dns.RR, this just keeps the fields from the Value, ignoring the Priority/Preference/Weight fields on the libdns.Record.

This also keeps the fix of turning an empty relative name in a libdns.Record into "@" before parsing it as a dns record. Without that change, setting records at the zone apex would fail (which will be detected properly as a FORMERR with PR #10).

For issue #11