### PR TITLE
Update to libdns v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/libdns/rfc2136
 go 1.22.0
 
 require (
-	github.com/libdns/libdns v1.0.0-beta.1.0.20250423132730-e0df105aed0e
+	github.com/libdns/libdns v1.0.0
 	github.com/miekg/dns v1.1.64
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/libdns/libdns v1.0.0-beta.1.0.20250423132730-e0df105aed0e h1:H1splZanuP6w1Krs4c76pBhNyVj+CZZa1o8nmm9c1wQ=
-github.com/libdns/libdns v1.0.0-beta.1.0.20250423132730-e0df105aed0e/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v1.0.0 h1:IvYaz07JNz6jUQ4h/fv2R4sVnRnm77J/aOuC9B+TQTA=
+github.com/libdns/libdns v1.0.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 github.com/miekg/dns v1.1.64 h1:wuZgD9wwCE6XMT05UU/mlSko71eRSXEAm2EbjQXLKnQ=
 github.com/miekg/dns v1.1.64/go.mod h1:Dzw9769uoKVaLuODMDZz9M6ynFU6Em65csPuoi8G0ck=
 golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=


### PR DESCRIPTION
[`libdns` v1.0.0 has been tagged](https://github.com/libdns/libdns/releases/tag/v1.0.0) with [no code changes from the current pinned commit](https://github.com/libdns/libdns/compare/e0df105aed0e...v1.0.0), so this PR upgrades to the latest tagged version.